### PR TITLE
Use corrected function name from silverstripe-cms project

### DIFF
--- a/code/reports/PagesScheduledForDeletionReport.php
+++ b/code/reports/PagesScheduledForDeletionReport.php
@@ -116,7 +116,7 @@ class PagesScheduledForDeletionReport extends SS_Report {
 		$records = singleton('SiteTree')->buildDataObjectSet($query->execute(), 'DataObjectSet', $query);
 
 		Versioned::reading_stage($stage);
-		if ($records) SiteTree::prepopuplate_permission_cache('edit', $records->column('ID'));
+		if ($records) SiteTree::prepopulate_permission_cache('edit', $records->column('ID'));
 		
 		// Filter to only those with canEdit permission
 		$filteredRecords = new DataObjectSet();

--- a/code/reports/PagesScheduledForPublishingReport.php
+++ b/code/reports/PagesScheduledForPublishingReport.php
@@ -76,7 +76,7 @@ class PagesScheduledForPublishingReport extends SS_Report {
 		// Turn a query into records
 		$records = singleton('SiteTree')->buildDataObjectSet($query->execute(), 'DataObjectSet', $query);
 		
-		if ($records) SiteTree::prepopuplate_permission_cache('edit', $records->column('ID'));
+		if ($records) SiteTree::prepopulate_permission_cache('edit', $records->column('ID'));
 
 		// Filter to only those with canEdit permission
 		$filteredRecords = new DataObjectSet();


### PR DESCRIPTION
The CMS project had a function named "SiteTree::prepopuplate_permission_cache" which
should be "SiteTree::prepopulate_permission_cache".  Since another commit corrected
the function name in that project, this project needs to use the new name.

See https://github.com/silverstripe/silverstripe-cms/pull/51 for the master pull request where the function was actually renamed.
